### PR TITLE
Add shebang notation to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 cmake CMakeLists.txt
 make splat


### PR DESCRIPTION
I'm using the fish shell, and I was getting this error when running `./build.sh`:

```
Failed to execute process './build.sh'. Reason:
exec: Exec format error
The file './build.sh' is marked as an executable but could not be run by the operating system.
```

So, I've added the `#/bin/sh` shebang notation to the top of the file should any other shells be picky in this instance.